### PR TITLE
Bugfix and tweaks

### DIFF
--- a/modules/k8s-namespace-roles/main.tf
+++ b/modules/k8s-namespace-roles/main.tf
@@ -112,5 +112,15 @@ resource "kubernetes_role" "rbac_tiller_resource_access" {
     verbs     = ["*"]
   }
 
+  # We include policy PodDisruptionBudget which is useful for the helm charts to manage
+  rule {
+    api_groups = [
+      "policy",
+    ]
+
+    resources = ["poddisruptionbudgets"]
+    verbs     = ["*"]
+  }
+
   depends_on = ["null_resource.dependency_getter"]
 }

--- a/modules/k8s-service-account/outputs.tf
+++ b/modules/k8s-service-account/outputs.tf
@@ -1,4 +1,6 @@
 output "name" {
   description = "The name of the created service account"
   value       = "${kubernetes_service_account.service_account.metadata.0.name}"
+
+  depends_on = ["kubernetes_role_binding.service_account_role_binding"]
 }


### PR DESCRIPTION
I ran into a bug in the example, where sometimes the `undeploy` fails because it removes the service account role before `undeploy`, stripping the Tiller pod of its ability to nuke itself. This fixes that by adding a `depends_on` to the service account output so that we delete the role binding when all resources referencing the service acocunt is deleted.

Secondly, this adds another set of permissions to the `rbac_tiller_resource_access` role that allows Tiller to manage `PodDisruptionBudgets`.