### PR TITLE
Implement create_resources flag for k8s-namespace and k8s-namespace-roles

### DIFF
--- a/modules/k8s-namespace-roles/main.tf
+++ b/modules/k8s-namespace-roles/main.tf
@@ -37,6 +37,9 @@ resource "null_resource" "dependency_getter" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "kubernetes_role" "rbac_role_access_all" {
+  count      = "${var.create_resources ? 1 : 0}"
+  depends_on = ["null_resource.dependency_getter"]
+
   metadata {
     name        = "${var.namespace}-access-all"
     namespace   = "${var.namespace}"
@@ -49,11 +52,12 @@ resource "kubernetes_role" "rbac_role_access_all" {
     resources  = ["*"]
     verbs      = ["*"]
   }
-
-  depends_on = ["null_resource.dependency_getter"]
 }
 
 resource "kubernetes_role" "rbac_role_access_read_only" {
+  count      = "${var.create_resources ? 1 : 0}"
+  depends_on = ["null_resource.dependency_getter"]
+
   metadata {
     name        = "${var.namespace}-access-read-only"
     namespace   = "${var.namespace}"
@@ -66,8 +70,6 @@ resource "kubernetes_role" "rbac_role_access_read_only" {
     resources  = ["*"]
     verbs      = ["get", "list", "watch"]
   }
-
-  depends_on = ["null_resource.dependency_getter"]
 }
 
 # These RBAC role permissions are based on the official example regarding deploying Tiller in a namespace to manage
@@ -75,6 +77,9 @@ resource "kubernetes_role" "rbac_role_access_read_only" {
 # See https://docs.helm.sh/using_helm/#example-deploy-tiller-in-a-namespace-restricted-to-deploying-resources-in-another-namespace
 
 resource "kubernetes_role" "rbac_tiller_metadata_access" {
+  count      = "${var.create_resources ? 1 : 0}"
+  depends_on = ["null_resource.dependency_getter"]
+
   metadata {
     name        = "${var.namespace}-tiller-metadata-access"
     namespace   = "${var.namespace}"
@@ -87,11 +92,12 @@ resource "kubernetes_role" "rbac_tiller_metadata_access" {
     resources  = ["secrets"]
     verbs      = ["*"]
   }
-
-  depends_on = ["null_resource.dependency_getter"]
 }
 
 resource "kubernetes_role" "rbac_tiller_resource_access" {
+  count      = "${var.create_resources ? 1 : 0}"
+  depends_on = ["null_resource.dependency_getter"]
+
   metadata {
     name        = "${var.namespace}-tiller-resource-access"
     namespace   = "${var.namespace}"
@@ -121,6 +127,4 @@ resource "kubernetes_role" "rbac_tiller_resource_access" {
     resources = ["poddisruptionbudgets"]
     verbs     = ["*"]
   }
-
-  depends_on = ["null_resource.dependency_getter"]
 }

--- a/modules/k8s-namespace-roles/outputs.tf
+++ b/modules/k8s-namespace-roles/outputs.tf
@@ -1,19 +1,19 @@
 output "rbac_access_all_role" {
   description = "The name of the RBAC role that grants admin level permissions on the namespace."
-  value       = "${kubernetes_role.rbac_role_access_all.metadata.0.name}"
+  value       = "${element(concat(kubernetes_role.rbac_role_access_all.*.metadata.0.name, list("")), 0)}"
 }
 
 output "rbac_access_read_only_role" {
   description = "The name of the RBAC role that grants read only permissions on the namespace."
-  value       = "${kubernetes_role.rbac_role_access_read_only.metadata.0.name}"
+  value       = "${element(concat(kubernetes_role.rbac_role_access_read_only.*.metadata.0.name, list("")), 0)}"
 }
 
 output "rbac_tiller_metadata_access_role" {
   description = "The name of the RBAC role that grants minimal permissions for Tiller to manage its metadata. Use this role if Tiller will be deployed into this namespace."
-  value       = "${kubernetes_role.rbac_tiller_metadata_access.metadata.0.name}"
+  value       = "${element(concat(kubernetes_role.rbac_tiller_metadata_access.*.metadata.0.name, list("")), 0)}"
 }
 
 output "rbac_tiller_resource_access_role" {
   description = "The name of the RBAC role that grants minimal permissions for Tiller to manage resources in this namespace."
-  value       = "${kubernetes_role.rbac_tiller_resource_access.metadata.0.name}"
+  value       = "${element(concat(kubernetes_role.rbac_tiller_resource_access.*.metadata.0.name, list("")), 0)}"
 }

--- a/modules/k8s-namespace-roles/variables.tf
+++ b/modules/k8s-namespace-roles/variables.tf
@@ -24,6 +24,11 @@ variable "annotations" {
   default     = {}
 }
 
+variable "create_resources" {
+  description = "Set to false to have this module create no resources. This weird parameter exists solely because Terraform does not support conditional modules. Therefore, this is a hack to allow you to conditionally decide if the Namespace roles should be created or not."
+  default     = true
+}
+
 # ---------------------------------------------------------------------------------------------------------------------
 # MODULE DEPENDENCIES
 # Workaround Terraform limitation where there is no module depends_on.

--- a/modules/k8s-namespace/main.tf
+++ b/modules/k8s-namespace/main.tf
@@ -31,13 +31,14 @@ resource "null_resource" "dependency_getter" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "kubernetes_namespace" "namespace" {
+  count      = "${var.create_resources ? 1 : 0}"
+  depends_on = ["null_resource.dependency_getter"]
+
   metadata {
     name        = "${var.name}"
     labels      = "${var.labels}"
     annotations = "${var.annotations}"
   }
-
-  depends_on = ["null_resource.dependency_getter"]
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -48,8 +49,10 @@ resource "kubernetes_namespace" "namespace" {
 module "namespace_roles" {
   source = "../k8s-namespace-roles"
 
-  namespace    = "${kubernetes_namespace.namespace.id}"
-  labels       = "${var.labels}"
-  annotations  = "${var.annotations}"
-  dependencies = ["${var.dependencies}"]
+  namespace   = "${kubernetes_namespace.namespace.id}"
+  labels      = "${var.labels}"
+  annotations = "${var.annotations}"
+
+  create_resources = "${var.create_resources}"
+  dependencies     = ["${var.dependencies}"]
 }

--- a/modules/k8s-namespace/outputs.tf
+++ b/modules/k8s-namespace/outputs.tf
@@ -1,6 +1,6 @@
 output "name" {
   description = "The name of the created namespace."
-  value       = "${kubernetes_namespace.namespace.id}"
+  value       = "${element(concat(kubernetes_namespace.namespace.*.id, list("")), 0)}"
 }
 
 output "rbac_access_all_role" {

--- a/modules/k8s-namespace/variables.tf
+++ b/modules/k8s-namespace/variables.tf
@@ -24,6 +24,11 @@ variable "annotations" {
   default     = {}
 }
 
+variable "create_resources" {
+  description = "Set to false to have this module create no resources. This weird parameter exists solely because Terraform does not support conditional modules. Therefore, this is a hack to allow you to conditionally decide if the Namespace should be created or not."
+  default     = true
+}
+
 # ---------------------------------------------------------------------------------------------------------------------
 # MODULE DEPENDENCIES
 # Workaround Terraform limitation where there is no module depends_on.


### PR DESCRIPTION
This implements our pattern of `create_resources` flag on `k8s-namespace` and `k8s-namespace-roles`. This isn't a standard pattern for us, but we introduce it to the modules when we have a need for it.

In this case, in the EKS ref arch, I intend to add in a namespace infra-module that adds Tiller, but introduce a conditional that allows the user to deploy tiller in a separate Namespace. So I need a flag to conditionally create the Tiller namespace.