### PR TITLE
Update source references to use https as opposed to git@

### DIFF
--- a/examples/k8s-namespace-with-service-account/main.tf
+++ b/examples/k8s-namespace-with-service-account/main.tf
@@ -21,7 +21,7 @@ provider "kubernetes" {
 module "namespace" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:gruntwork-io/terraform-kubernetes-helm.git//modules/k8s-namespace?ref=v0.0.1"
+  # source = "git::https://github.com/gruntwork-io/terraform-kubernetes-helm.git//modules/k8s-namespace?ref=v0.0.1"
   source = "../../modules/k8s-namespace"
 
   name = "${var.name}"
@@ -34,7 +34,7 @@ module "namespace" {
 module "service_account_access_all" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:gruntwork-io/terraform-kubernetes-helm.git//modules/k8s-service-account?ref=v0.0.1"
+  # source = "git::https://github.com/gruntwork-io/terraform-kubernetes-helm.git//modules/k8s-service-account?ref=v0.0.1"
   source = "../../modules/k8s-service-account"
 
   name           = "${var.name}-admin"
@@ -55,7 +55,7 @@ module "service_account_access_all" {
 module "service_account_access_read_only" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:gruntwork-io/terraform-kubernetes-helm.git//modules/k8s-service-account?ref=v0.0.1"
+  # source = "git::https://github.com/gruntwork-io/terraform-kubernetes-helm.git//modules/k8s-service-account?ref=v0.0.1"
   source = "../../modules/k8s-service-account"
 
   name           = "${var.name}-read-only"

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ provider "kubernetes" {
 module "tiller_namespace" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:gruntwork-io/terraform-kubernetes-helm.git//modules/k8s-namespace?ref=v0.3.0"
+  # source = "git::https://github.com/gruntwork-io/terraform-kubernetes-helm.git//modules/k8s-namespace?ref=v0.3.0"
   source = "./modules/k8s-namespace"
 
   name = "${var.tiller_namespace}"
@@ -31,7 +31,7 @@ module "tiller_namespace" {
 module "resource_namespace" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:gruntwork-io/terraform-kubernetes-helm.git//modules/k8s-namespace?ref=v0.3.0"
+  # source = "git::https://github.com/gruntwork-io/terraform-kubernetes-helm.git//modules/k8s-namespace?ref=v0.3.0"
   source = "./modules/k8s-namespace"
 
   name = "${var.resource_namespace}"
@@ -40,7 +40,7 @@ module "resource_namespace" {
 module "tiller_service_account" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:gruntwork-io/terraform-kubernetes-helm.git//modules/k8s-service-account?ref=v0.3.0"
+  # source = "git::https://github.com/gruntwork-io/terraform-kubernetes-helm.git//modules/k8s-service-account?ref=v0.3.0"
   source = "./modules/k8s-service-account"
 
   name           = "${var.service_account_name}"
@@ -88,7 +88,7 @@ resource "null_resource" "tiller_tls_certs" {
 module "tiller" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:gruntwork-io/terraform-kubernetes-helm.git//modules/k8s-tiller?ref=v0.3.0"
+  # source = "git::https://github.com/gruntwork-io/terraform-kubernetes-helm.git//modules/k8s-tiller?ref=v0.3.0"
   source = "./modules/k8s-tiller"
 
   tiller_service_account_name              = "${module.tiller_service_account.name}"

--- a/modules/k8s-namespace/README.md
+++ b/modules/k8s-namespace/README.md
@@ -43,12 +43,12 @@ We create the namespaces using this module:
 
 ```
 module "core_namespace" {
-  source = "git::git@github.com:gruntwork-io/package-k8s.git//modules/k8s-namespace?ref=v0.1.0"
+  source = "git::https://github.com/gruntwork-io/terraform-kubernetes-helm.git//modules/k8s-namespace?ref=v0.1.0"
   name = "core"
 }
 
 module "analytics_namespace" {
-  source = "git::git@github.com:gruntwork-io/package-k8s.git//modules/k8s-namespace?ref=v0.1.0"
+  source = "git::https://github.com/gruntwork-io/terraform-kubernetes-helm.git//modules/k8s-namespace?ref=v0.1.0"
   name = "analytics"
 }
 ```

--- a/modules/k8s-tiller/README.md
+++ b/modules/k8s-tiller/README.md
@@ -55,13 +55,13 @@ sets that you can use in the [k8s-namespace-roles module](../k8s-namespace-roles
 
 ```hcl
 module "namespace_roles" {
-  source = "git::git@github.com:gruntwork-io/terraform-kubernetes-helm.git//modules/k8s-namespace-roles?ref=v0.3.0"
+  source = "git::https://github.com/gruntwork-io/terraform-kubernetes-helm.git//modules/k8s-namespace-roles?ref=v0.3.0"
 
   namespace    = "kube-system"
 }
 
 module "tiller_service_account" {
-  source = "git::git@github.com:gruntwork-io/terraform-kubernetes-helm.git//modules/k8s-service-account?ref=v0.3.0"
+  source = "git::https://github.com/gruntwork-io/terraform-kubernetes-helm.git//modules/k8s-service-account?ref=v0.3.0"
 
   name           = "tiller"
   namespace      = "kube-system"


### PR DESCRIPTION
Since this repo is now public, we should use `https` for better anonymous pulls.