### PR TITLE
Use absolute links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,16 @@
 
 # Tiller Module
 
+<!-- NOTE: We use absolute linking here instead of relative linking, because the terraform registry does not support
+           relative linking correctly.
+-->
+
 This repo contains a Module for deploying Tiller (the server component of Helm) on Kubernetes clusters with
 [Terraform](https://www.terraform.io).  This repo is a part of [the Gruntwork Infrastructure as Code
 Library](https://gruntwork.io/infrastructure-as-code-library/), a collection of reusable, battle-tested, production
-ready infrastructure code. Read the [Gruntwork Philosophy](GRUNTWORK_PHILOSOPHY.md) document to learn more about how
-Gruntwork builds production grade infrastructure code.
+ready infrastructure code. Read the [Gruntwork
+Philosophy](https://github.com/gruntwork-io/terraform-kubernetes-helm/blob/master/GRUNTWORK_PHILOSOPHY.md) document to
+learn more about how Gruntwork builds production grade infrastructure code.
 
 
 ## Quickstart Guide
@@ -26,24 +31,26 @@ The general idea is to:
    Tiller instance.
 1. Deploy Tiller.
 
-You can checkout the [`k8s-tiller-minikube` example documentation](/examples/k8s-tiller-minikube/README.md) for detailed
-instructions on deploying against `minikube`.
+You can checkout the [`k8s-tiller-minikube` example
+documentation](https://github.com/gruntwork-io/terraform-kubernetes-helm/tree/master/examples/k8s-tiller-minikube) for
+detailed instructions on deploying against `minikube`.
 
 
 ## What is in this repo
 
 This repo provides a Gruntwork IaC Package and has the following folder structure:
 
-* [root](./): The root folder contains an example of how to deploy Tiller using
-  [`kubergrunt`](https://github.com/gruntwork-io/kubergrunt), which implements all the logic for deploying Tiller with
-  all the security best practices.
-* [modules](/modules): This folder contains the main implementation code for this Module, broken down into multiple
-  standalone Submodules.
+* [root](https://github.com/gruntwork-io/terraform-kubernetes-helm): The root folder contains an example of how to
+  deploy Tiller using [`kubergrunt`](https://github.com/gruntwork-io/kubergrunt), which implements all the logic for
+  deploying Tiller with all the security best practices.
+* [modules](https://github.com/gruntwork-io/terraform-kubernetes-helm/tree/master/modules): This folder contains the
+  main implementation code for this Module, broken down into multiple standalone Submodules.
 
   The primary module is:
 
-    * [k8s-tiller](/modules/k8s-tiller): Deploy Tiller with all the security features turned on. This includes using
-      `Secrets` for storing state and enabling TLS verification.
+    * [k8s-tiller](https://github.com/gruntwork-io/terraform-kubernetes-helm/tree/master/modules/k8s-tiller): Deploy
+      Tiller with all the security features turned on. This includes using `Secrets` for storing state and enabling TLS
+      verification.
 
     The deployed Tiller requires TLS certificate key pairs to operate. Additionally, clients will each need to their
     own TLS certificate key pairs to authenticate to the deployed Tiller instance. This is based on [kubergrunt model of
@@ -51,13 +58,17 @@ This repo provides a Gruntwork IaC Package and has the following folder structur
 
     There are also several supporting modules that help with setting up the deployment:
 
-    * [k8s-namespace](/modules/k8s-namespace): Provision a Kubernetes `Namespace` with a default set of RBAC roles.
-    * [k8s-namespace-roles](/modules/k8s-namespace-roles): Provision a default set of RBAC roles to use in a `Namespace`.
-    * [k8s-service-account](/modules/k8s-service-account): Provision a Kubernetes `ServiceAccount`.
+    * [k8s-namespace](https://github.com/gruntwork-io/terraform-kubernetes-helm/tree/master/modules/k8s-namespace):
+      Provision a Kubernetes `Namespace` with a default set of RBAC roles.
+    * [k8s-namespace-roles](https://github.com/gruntwork-io/terraform-kubernetes-helm/tree/master/modules/k8s-namespace-roles):
+      Provision a default set of RBAC roles to use in a `Namespace`.
+    * [k8s-service-account](https://github.com/gruntwork-io/terraform-kubernetes-helm/tree/master/modules/k8s-service-account):
+      Provision a Kubernetes `ServiceAccount`.
 
-* [examples](/examples): This folder contains examples of how to use the Submodules. The [example root
-  README](/examples/README.md) provides a quickstart guide on how to use the Submodules in this Module.
-* [test](/test): Automated tests for the Submodules and examples.
+* [examples](https://github.com/gruntwork-io/terraform-kubernetes-helm/tree/master/examples): This folder contains
+  examples of how to use the Submodules.
+* [test](https://github.com/gruntwork-io/terraform-kubernetes-helm/tree/master/test): Automated tests for the Submodules
+  and examples.
 
 
 ## What is Kubernetes?
@@ -113,13 +124,14 @@ Gruntwork can help with:
 
 ## How do I contribute to this Module?
 
-Contributions are very welcome! Check out the [Contribution Guidelines](/CONTRIBUTING.md) for instructions.
+Contributions are very welcome! Check out the [Contribution
+Guidelines](https://github.com/gruntwork-io/terraform-kubernetes-helm/blob/master/CONTRIBUTING.md) for instructions.
 
 
 ## How is this Module versioned?
 
 This Module follows the principles of [Semantic Versioning](http://semver.org/). You can find each new release, along
-with the changelog, in the [Releases Page](../../releases).
+with the changelog, in the [Releases Page](https://github.com/gruntwork-io/terraform-kubernetes-helm/releases).
 
 During initial development, the major version will be 0 (e.g., `0.x.y`), which indicates the code does not yet have a
 stable API. Once we hit `1.0.0`, we will make every effort to maintain a backwards compatible API and use the MAJOR,
@@ -128,6 +140,7 @@ MINOR, and PATCH versions on each release to indicate any incompatibilities.
 
 ## License
 
-Please see [LICENSE](/LICENSE) for how the code in this repo is licensed.
+Please see [LICENSE](https://github.com/gruntwork-io/terraform-kubernetes-helm/blob/master/LICENSE) for how the code in
+this repo is licensed.
 
 Copyright &copy; 2019 Gruntwork, Inc.

--- a/modules/k8s-namespace-roles/README.md
+++ b/modules/k8s-namespace-roles/README.md
@@ -1,5 +1,9 @@
 # K8S Namespace Roles Module
 
+<!-- NOTE: We use absolute linking here instead of relative linking, because the terraform registry does not support
+           relative linking correctly.
+-->
+
 This Terraform Module defines a set of common Kubernetes
 [RBAC `Roles`](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) for a `Namespace`. The following roles
 will be provided by this module:
@@ -15,11 +19,15 @@ will be provided by this module:
 
 ## How do you use this module?
 
-* See the [root README](/README.md) for instructions on using Terraform modules.
+* See the [root README](https://github.com/gruntwork-io/terraform-kubernetes-helm/blob/master/README.md) for
+  instructions on using Terraform modules.
 * This module uses [the `kubernetes` provider](https://www.terraform.io/docs/providers/kubernetes/index.html).
-* See the [examples](/examples) folder for example usage.
-* See [variables.tf](./variables.tf) for all the variables you can set on this module.
-* See [outputs.tf](./outputs.tf) for all the variables that are outputed by this module.
+* See the [examples](https://github.com/gruntwork-io/terraform-kubernetes-helm/tree/master/examples) folder for example
+  usage.
+* See [variables.tf](https://github.com/gruntwork-io/terraform-kubernetes-helm/blob/master/modules/k8s-namespace-roles/variables.tf)
+  for all the variables you can set on this module.
+* See [outputs.tf](https://github.com/gruntwork-io/terraform-kubernetes-helm/blob/master/modules/k8s-namespace-roles/outputs.tf)
+  for all the variables that are outputed by this module.
 
 
 ## What is Kubernetes Role Based Access Control (RBAC)?

--- a/modules/k8s-namespace/README.md
+++ b/modules/k8s-namespace/README.md
@@ -1,5 +1,9 @@
 # K8S Namespace Module
 
+<!-- NOTE: We use absolute linking here instead of relative linking, because the terraform registry does not support
+           relative linking correctly.
+-->
+
 This Terraform Module manages Kubernetes
 [`Namespaces`](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/). In addition to creating
 namespaces, this module will create a set of default RBAC roles restricted to that namespace. The following roles will
@@ -16,11 +20,14 @@ be provided by this module:
 
 ## How do you use this module?
 
-* See the [root README](/README.md) for instructions on using Terraform modules.
+* See the [root README](https://github.com/gruntwork-io/terraform-kubernetes-helm/blob/master/README.md) for instructions on using Terraform modules.
 * This module uses [the `kubernetes` provider](https://www.terraform.io/docs/providers/kubernetes/index.html).
-* See the [examples](/examples) folder for example usage.
-* See [variables.tf](./variables.tf) for all the variables you can set on this module.
-* See [outputs.tf](./outputs.tf) for all the variables that are outputed by this module.
+* See the [examples](https://github.com/gruntwork-io/terraform-kubernetes-helm/tree/master/examples) folder for example
+  usage.
+* See [variables.tf](https://github.com/gruntwork-io/terraform-kubernetes-helm/blob/master/modules/k8s-namespace/variables.tf)
+  for all the variables you can set on this module.
+* See [outputs.tf](https://github.com/gruntwork-io/terraform-kubernetes-helm/blob/master/modules/k8s-namespace/outputs.tf)
+  for all the variables that are outputed by this module.
 
 
 ## What is a Namespace?

--- a/modules/k8s-service-account/README.md
+++ b/modules/k8s-service-account/README.md
@@ -1,5 +1,9 @@
 # K8S ServiceAccount Module
 
+<!-- NOTE: We use absolute linking here instead of relative linking, because the terraform registry does not support
+           relative linking correctly.
+-->
+
 This Terraform Module manages Kubernetes
 [`ServiceAccounts`](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/). This module
 can be used to declaratively create and update `ServiceAccounts` and the bound permissions that it has.
@@ -7,11 +11,15 @@ can be used to declaratively create and update `ServiceAccounts` and the bound p
 
 ## How do you use this module?
 
-* See the [root README](/README.md) for instructions on using Terraform modules.
+* See the [root README](https://github.com/gruntwork-io/terraform-kubernetes-helm/blob/master/README.md) for
+  instructions on using Terraform modules.
 * This module uses [the `kubernetes` provider](https://www.terraform.io/docs/providers/kubernetes/index.html).
-* See the [examples](/examples) folder for example usage.
-* See [variables.tf](./variables.tf) for all the variables you can set on this module.
-* See [outputs.tf](./outputs.tf) for all the variables that are outputed by this module.
+* See the [examples](https://github.com/gruntwork-io/terraform-kubernetes-helm/tree/master/examples) folder for example
+  usage.
+* See [variables.tf](https://github.com/gruntwork-io/terraform-kubernetes-helm/blob/master/modules/k8s-service-account/variables.tf)
+  for all the variables you can set on this module.
+* See [outputs.tf](https://github.com/gruntwork-io/terraform-kubernetes-helm/blob/master/modules/k8s-service-account/outputs.tf)
+  for all the variables that are outputed by this module.
 
 
 ## What is a ServiceAccount?

--- a/modules/k8s-tiller/README.md
+++ b/modules/k8s-tiller/README.md
@@ -1,5 +1,9 @@
 # K8S Tiller (Helm Server) Module
 
+<!-- NOTE: We use absolute linking here instead of relative linking, because the terraform registry does not support
+           relative linking correctly.
+-->
+
 This Terraform Module can be used to declaratively deploy and manage multiple Tiller (the server component of Helm)
 deployments in a single Kubernetes cluster.
 Unlike the defaults installed by the helm client, the deployed Tiller instances:
@@ -14,11 +18,15 @@ repository will be updated with migration instructions to help smooth out the up
 
 ## How do you use this module?
 
-* See the [root README](/README.md) for instructions on using Terraform modules.
+* See the [root README](https://github.com/gruntwork-io/terraform-kubernetes-helm/blob/master/README.md) for
+  instructions on using Terraform modules.
 * This module uses [the `kubernetes` provider](https://www.terraform.io/docs/providers/kubernetes/index.html).
-* See [the example at the root of the repo](/) for example usage.
-* See [variables.tf](./variables.tf) for all the variables you can set on this module.
-* See [outputs.tf](./outputs.tf) for all the variables that are outputed by this module.
+* See [the example at the root of the repo](https://github.com/gruntwork-io/terraform-kubernetes-helm) for example
+  usage.
+* See [variables.tf](https://github.com/gruntwork-io/terraform-kubernetes-helm/blob/master/modules/k8s-tiller/variables.tf)
+  for all the variables you can set on this module.
+* See [outputs.tf](https://github.com/gruntwork-io/terraform-kubernetes-helm/blob/master/modules/k8s-tiller/outputs.tf)
+  for all the variables that are outputed by this module.
 
 
 ## What is Tiller?
@@ -48,10 +56,11 @@ installs to only manage resources in particular namespaces, or even restrict wha
 
 The specific roles to use for Tiller depends on your infrastructure needs. At a minimum, Tiller needs enough permissions
 to manage its own metadata, and permissions to deploy resources in the target Namespace. We provide minimal permission
-sets that you can use in the [k8s-namespace-roles module](../k8s-namespace-roles). You can associate the
-`rbac_tiller_metadata_access_role` and `rbac_tiller_resource_access_role` roles created by the module to the Tiller
-`ServiceAccount` to grant those permissions. For example, the following terraform code will create these roles in the
-`kube-system` `Namespace` and attach it to a new `ServiceAccount` that you can then use in this module:
+sets that you can use in the [k8s-namespace-roles
+module](https://github.com/gruntwork-io/terraform-kubernetes-helm/tree/master/modules/k8s-namespace-roles). You can
+associate the `rbac_tiller_metadata_access_role` and `rbac_tiller_resource_access_role` roles created by the module to
+the Tiller `ServiceAccount` to grant those permissions. For example, the following terraform code will create these
+roles in the `kube-system` `Namespace` and attach it to a new `ServiceAccount` that you can then use in this module:
 
 ```hcl
 module "namespace_roles" {
@@ -118,5 +127,6 @@ To summarize, assuming a single client, in this model we have three sets of TLS 
 You can use `kubergrunt` to manage TLS certificates optimized for use with Tiller. `kubergrunt` provides various
 primitives that can be used for generating and managing TLS certificates using Kubernetes `Secrets`. This allows you to
 manage access to Helm using the RBAC system of Kubernetes. See the [k8s-tiller-minikube
-example](/examples/k8s-tiller-minikube) for an example of how to use `kubergrunt` to generate TLS certs for use with
+example](https://github.com/gruntwork-io/terraform-kubernetes-helm/tree/master/examples/k8s-tiller-minikube) for an
+example of how to use `kubergrunt` to generate TLS certs for use with
 this module.


### PR DESCRIPTION
Relative linking does not work on the terraform registry because it doesn't have our entire repo structure there, so we adjust by using absolute linking in the root READMEs of each module and repo.