### PR TITLE
Fix #39

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -17,7 +17,7 @@ output "helm_client_tls_private_key_pem" {
 output "helm_client_tls_public_cert_pem" {
   description = "The public certificate of the TLS certificate key pair to use for the helm client."
   sensitive   = true
-  value       = module.helm_client_tls_certs.tls_certificate_key_pair_private_key_pem
+  value       = module.helm_client_tls_certs.tls_certificate_key_pair_certificate_pem
 }
 
 output "helm_client_tls_ca_cert_pem" {


### PR DESCRIPTION
The `helm_client_tls_public_cert_pem` output should output the public certificate, not the private key.