### PR TITLE
Fix CircleCI Contexts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,15 +154,9 @@ workflows:
               only: master
     jobs:
       - setup:
-          context:
-            - Gruntwork Admin
       - integration_tests:
           requires:
             - setup
-          context:
-            - Gruntwork Admin
       - integration_tests_without_kubergrunt:
           requires:
             - setup
-          context:
-            - Gruntwork Admin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       - save_cache:
           key: dep-{{ checksum "test/Gopkg.lock" }}
           paths:
-            - ./test/vendor
+          - ./test/vendor
       # Fail the build if the pre-commit hooks don't pass. Note: if you run pre-commit install locally, these hooks will
       # execute automatically every time before you commit, ensuring the build never fails at this step!
       - run: pip install pre-commit==1.11.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ workflows:
             branches:
               only: master
     jobs:
-      - setup:
+      - setup
       - integration_tests:
           requires:
             - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - dep-{{ checksum "test/Gopkg.lock" }}
+          - dep-{{ checksum "test/Gopkg.lock" }}
       # Install gruntwork utilities
       - run:
           <<: *install_gruntwork_utils

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,8 @@ defaults: &defaults
     TERRAGRUNT_VERSION: NONE
     PACKER_VERSION: NONE
     GOLANG_VERSION: 1.11.2
-    K8S_VERSION: v1.10.0  # Same as EKS
+    K8S_VERSION: v1.10.0 # Same as EKS
     KUBECONFIG: /home/circleci/.kube/config
-
-
 install_helm_client: &install_helm_client
   name: install helm
   command: |
@@ -24,8 +22,6 @@ install_helm_client: &install_helm_client
     tar -xvf helm.tar.gz
     chmod +x linux-amd64/helm
     sudo mv linux-amd64/helm /usr/local/bin/
-
-
 install_gruntwork_utils: &install_gruntwork_utils
   name: install gruntwork utils
   command: |
@@ -41,8 +37,6 @@ install_gruntwork_utils: &install_gruntwork_utils
       --use-go-dep \
       --go-version ${GOLANG_VERSION} \
       --go-src-path test \
-
-
 version: 2
 jobs:
   setup:
@@ -51,52 +45,41 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - dep-{{ checksum "test/Gopkg.lock" }}
-
+            - dep-{{ checksum "test/Gopkg.lock" }}
       # Install gruntwork utilities
       - run:
           <<: *install_gruntwork_utils
-
       - save_cache:
           key: dep-{{ checksum "test/Gopkg.lock" }}
           paths:
-          - ./test/vendor
-
+            - ./test/vendor
       # Fail the build if the pre-commit hooks don't pass. Note: if you run pre-commit install locally, these hooks will
       # execute automatically every time before you commit, ensuring the build never fails at this step!
       - run: pip install pre-commit==1.11.2
       - run: pre-commit install
       - run: pre-commit run --all-files
-
       - persist_to_workspace:
           root: /home/circleci
           paths:
             - project
             - terraform
             - packer
-
   integration_tests:
     <<: *defaults
     steps:
       - attach_workspace:
           at: /home/circleci
-
       # The weird way you have to set PATH in Circle 2.0
       - run: echo 'export PATH=$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
-
       - run:
           <<: *install_gruntwork_utils
-
       - run:
           command: setup-minikube
-
       - run:
           <<: *install_helm_client
-
       - run:
           name: Install kubergrunt
           command: gruntwork-install --binary-name "kubergrunt" --repo "https://github.com/gruntwork-io/kubergrunt" --tag "${KUBERGRUNT_VERSION}"
-
       # Execute main terratests
       - run:
           name: run integration tests
@@ -104,7 +87,6 @@ jobs:
             mkdir -p /tmp/logs
             run-go-tests --path test --timeout 60m | tee /tmp/logs/all.log
           no_output_timeout: 3600s
-
       - run:
           command: terratest_log_parser --testlog /tmp/logs/all.log --outputdir /tmp/logs
           when: always
@@ -112,22 +94,17 @@ jobs:
           path: /tmp/logs
       - store_test_results:
           path: /tmp/logs
-
   integration_tests_without_kubergrunt:
     <<: *defaults
     steps:
       - attach_workspace:
           at: /home/circleci
-
       # The weird way you have to set PATH in Circle 2.0
       - run: echo 'export PATH=$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
-
       - run:
           <<: *install_gruntwork_utils
-
       - run:
           command: setup-minikube
-
       # Execute main terratests
       - run:
           name: run integration tests
@@ -135,7 +112,6 @@ jobs:
             mkdir -p /tmp/logs
             run-go-tests --path test --timeout 60m --packages "-run TestK8STillerNoKubergrunt$ ." | tee /tmp/logs/all.log
           no_output_timeout: 3600s
-
       - run:
           command: terratest_log_parser --testlog /tmp/logs/all.log --outputdir /tmp/logs
           when: always
@@ -143,30 +119,32 @@ jobs:
           path: /tmp/logs
       - store_test_results:
           path: /tmp/logs
-
 workflows:
   version: 2
   test-and-deploy:
     jobs:
-    - setup:
-        filters:
-          tags:
-            only: /^v.*/
-
-    - integration_tests:
-        requires:
-          - setup
-        filters:
-          tags:
-            only: /^v.*/
-
-    - integration_tests_without_kubergrunt:
-        requires:
-          - setup
-        filters:
-          tags:
-            only: /^v.*/
-
+      - setup:
+          filters:
+            tags:
+              only: /^v.*/
+          context:
+            - Gruntwork Admin
+      - integration_tests:
+          requires:
+            - setup
+          filters:
+            tags:
+              only: /^v.*/
+          context:
+            - Gruntwork Admin
+      - integration_tests_without_kubergrunt:
+          requires:
+            - setup
+          filters:
+            tags:
+              only: /^v.*/
+          context:
+            - Gruntwork Admin
   nightly:
     triggers:
       - schedule:
@@ -175,10 +153,16 @@ workflows:
             branches:
               only: master
     jobs:
-      - setup
+      - setup:
+          context:
+            - Gruntwork Admin
       - integration_tests:
           requires:
             - setup
+          context:
+            - Gruntwork Admin
       - integration_tests_without_kubergrunt:
           requires:
             - setup
+          context:
+            - Gruntwork Admin


### PR DESCRIPTION
This pull request was programmatically opened by the multi-repo-updater program. It should be adding the 'Gruntwork Admin' context to any Workflows -> Jobs nodes and should also be leaving the rest of the .circleci/config.yml file alone. 

 This PR was opened so that all our repositories' .circleci/config.yml files can be converted to use the same CircleCI context, which will make rotating secrets much easier in the future.