### PR TITLE
Disable nightly test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,19 +166,3 @@ workflows:
         filters:
           tags:
             only: /^v.*/
-
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 5 * * *"
-          filters:
-            branches:
-              only: master
-    jobs:
-      - setup
-      - integration_tests:
-          requires:
-            - setup
-      - integration_tests_without_kubergrunt:
-          requires:
-            - setup


### PR DESCRIPTION
This disables nightly testing on this repo. Note that we intend on archiving this and replacing it with another repo that only has the minimal modules we intend to support for helm 3 (`namespace` + `service-account`), so no need to do CircleCI contexts (we can just remove the env vars from the job).